### PR TITLE
Update computational efficiency of form_schema_ext.R

### DIFF
--- a/R/form_schema_ext.R
+++ b/R/form_schema_ext.R
@@ -150,6 +150,7 @@ form_schema_ext <- function(flatten = FALSE,
 
   ### parse translations
   all_translations <- xml2::xml_find_all(frm_xml, "//text")
+  all_translations_ids <-xml2::xml_attr(all_translations, "id")
 
   # initialize dataframe
   extension <- data.frame(
@@ -196,7 +197,7 @@ form_schema_ext <- function(flatten = FALSE,
           sub("jr:itext\\('", "", xml2::xml_attr(this_rawlabel, "ref"))
         )
         translations <- all_translations[
-          xml2::xml_attr(all_translations, "id") == id
+          all_translations_ids == id
         ]
 
         # iterate through translations
@@ -312,9 +313,9 @@ form_schema_ext <- function(flatten = FALSE,
               )
             )
 
-            choice_translations <- all_translations[xml2::xml_attr(
-              all_translations, "id"
-            ) == id_choice]
+            choice_translations <- all_translations[
+              all_translations_ids == id_choice
+            ]
 
 
             # iterate through choice translations


### PR DESCRIPTION
While testing `form_schema_ext()` with a large form, it was taking about 3 min to run this function.

After close inspection I realized that the chunks:

```r
        translations <- all_translations[
          xml2::xml_attr(all_translations, "id") == id
        ]
```

and

```r
            choice_translations <- all_translations[xml2::xml_attr(
              all_translations, "id"
            ) == id_choice]
```

Are computationally inefficient due to the unnecessary repetition of   `xml2::xml_attr(all_translations, "id")`. By adding this once at the top and using the resulting object to select specific rows, I reduced computational time by 90%. 

Function was taking 3 minutes and it takes now 20 seconds.

Nothing else changes structurally