### PR TITLE
Feature/extend schema with choice filter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # `ruODK` (development version)
 ## Major fixes
+* `form_schema_ext` retrieves choice lists when choice filters are present
+   (#105,  @mtyszler).
 ## Minor fixes
 ## Documentation
 ## Data

--- a/R/form_schema_ext.R
+++ b/R/form_schema_ext.R
@@ -541,7 +541,12 @@ form_schema_ext <- function(flatten = FALSE,
             }
           }
           else {
-            #choice_labels[["base"]][jj] <- xml2::xml_text(this_rawchoicelabel)
+            choice_labels[["base"]][jj] <- xml2::xml_text(
+              xml2::xml_find_first(this_choiceitem, 
+                                   paste0("./",choicelabel_node)
+                                   )
+            )
+
           }
         }
         

--- a/R/form_schema_ext.R
+++ b/R/form_schema_ext.R
@@ -66,7 +66,7 @@
 #'   \item \code{choices} A list of lists containing at least \code{values} and,
 #'     if available, \code{labels} of the choices as given in the form schema.
 #'     If specific languages are available, this column will return the
-#'     \code{default} language or it will be empty if this is not specified. 
+#'     \code{default} language or it will be empty if this is not specified.
 #'     Please notice that whenever choice filters are applied, this will return
 #'     the unfiltered choice list.
 #'   \item \code{choices_lang} A list of lists containing at least
@@ -401,35 +401,35 @@ form_schema_ext <- function(flatten = FALSE,
           )))
         }
       }
-      
-      ### PART 1.2: parse complex choice labels, 
+
+      ### PART 1.2: parse complex choice labels,
       # i.e. in the presence of choice filters
-      
+
       ## check existence of  choice itemset:
       choice_itemset <- xml2::xml_find_all(
         xml2::xml_parent(this_rawlabel), "./itemset"
       )
-      
-      
+
+
       if (length(choice_itemset) > 0) {
-        
+
         # identify value node
         choicevalue_node <- xml2::xml_attr(
           xml2::xml_find_first(choice_itemset, "./value"),
           "ref"
         )
-        
+
         # identify label node
         choicelabel_node <- xml2::xml_attr(
           xml2::xml_find_first(choice_itemset, "./label"),
           "ref"
         )
-        
+
         # check if labels have translations
-        has_translation_choice <- grepl("jr:itext",choicelabel_node)
-        
-        if(has_translation_choice) {
-          #update choicelabel_node
+        has_translation_choice <- grepl("jr:itext", choicelabel_node)
+
+        if (has_translation_choice) {
+          # update choicelabel_node
           choicelabel_node <- sub(
             ")",
             "",
@@ -440,59 +440,65 @@ form_schema_ext <- function(flatten = FALSE,
             )
           )
         }
-        
+
         # extract content from the itemset:
-        choice_nodeset<-xml2::xml_attr(choice_itemset, "nodeset")
-        choice_nodeset_id <-substr(choice_nodeset,
-                                   regexpr("\\(", choice_nodeset)[1]+1,
-                                   regexpr(")", choice_nodeset)[1]-1)
-        choice_itemset_content<-xml2::xml_find_all(frm_xml,
-                                                   paste0(".//instance[@id=",
-                                                          choice_nodeset_id,
-                                                          "]//item"))
-        
-        
+        choice_nodeset <- xml2::xml_attr(choice_itemset, "nodeset")
+        choice_nodeset_id <- substr(
+          choice_nodeset,
+          regexpr("\\(", choice_nodeset)[1] + 1,
+          regexpr(")", choice_nodeset)[1] - 1
+        )
+        choice_itemset_content <- xml2::xml_find_all(
+          frm_xml,
+          paste0(
+            ".//instance[@id=",
+            choice_nodeset_id,
+            "]//item"
+          )
+        )
+
+
         # check if 'choices' column already exist
         if (!("choices" %in% colnames(extension))) {
-          
+
           # if not, create new column
           extension <- cbind(extension, data.frame(
             choices = rep(NA, nrow(extension))
           ))
         }
-        
+
         # initialize lists
         choice_values <- list()
         choice_labels <- list()
-        
+
         # iterate through choice list:
         for (jj in seq_along(choice_itemset_content)) {
-          
+
           ## read choice item
           this_choiceitem <- choice_itemset_content[jj]
-          
+
           # value
           this_choicevalue <- xml2::xml_text(
-            xml2::xml_find_first(this_choiceitem, paste0("./",choicevalue_node))
+            xml2::xml_find_first(this_choiceitem, paste0("./", choicevalue_node))
           )
           choice_values[jj] <- this_choicevalue
-          
+
           if (has_translation_choice) {
             id_choice <- xml2::xml_text(
-              xml2::xml_find_first(this_choiceitem, paste0("./",choicelabel_node))
+              xml2::xml_find_first(this_choiceitem, paste0("./", choicelabel_node))
             )
-            
+
             choice_translations <- all_translations[
               all_translations_ids == id_choice
-              ]
-            
-            
+            ]
+
+
             # iterate through choice translations
             for (kk in seq_along(choice_translations)) {
-              
+
               # read translation
               this_choicetranslation <- choice_translations[kk]
-              
+
               # first check this is a regular text labels.
               # Questions in ODK can have video, image and audio "labels",
               # which will be skipped.
@@ -500,7 +506,7 @@ form_schema_ext <- function(flatten = FALSE,
               is_regular_choicelabel <- !xml2::xml_has_attr(
                 xml2::xml_find_first(this_choicetranslation, "./value"), "form"
               )
-              
+
               if (is_regular_choicelabel) {
                 # read the parent node to identify language:
                 choice_translation_parent <- xml2::xml_parent(
@@ -509,7 +515,7 @@ form_schema_ext <- function(flatten = FALSE,
                 this_choicelang <- gsub(" ", "_", tolower(xml2::xml_attr(
                   choice_translation_parent, "lang"
                 )))
-                
+
                 # decide if 'default' language or specific language
                 if (this_choicelang == "default") {
                   # if 'default' language, save under 'choice':
@@ -520,8 +526,8 @@ form_schema_ext <- function(flatten = FALSE,
                 else {
                   # check if language already exists in the dataframe
                   if (!(paste0("choices_", this_choicelang) %in%
-                        colnames(extension))) {
-                    
+                    colnames(extension))) {
+
                     # if not, create new column
                     extension <- cbind(extension, data.frame(
                       new_choicelang = rep(NA, nrow(extension))
@@ -530,7 +536,7 @@ form_schema_ext <- function(flatten = FALSE,
                       "choices_", this_choicelang
                     )
                   }
-                  
+
                   # add the first value content of the translation
                   choice_labels[[paste0(
                     "choices_",
@@ -546,25 +552,25 @@ form_schema_ext <- function(flatten = FALSE,
           }
           else {
             choice_labels[["base"]][jj] <- xml2::xml_text(
-              xml2::xml_find_first(this_choiceitem, 
-                                   paste0("./",choicelabel_node)
-                                   )
+              xml2::xml_find_first(
+                this_choiceitem,
+                paste0("./", choicelabel_node)
+              )
             )
-
           }
         }
-        
+
         # add to the extended table
         for (this_choicelang in names(choice_labels)) {
           these_choicelabels <- choice_labels[[this_choicelang]]
-          
+
           if (this_choicelang == "base") {
             this_choicelang_colname <- "choices"
           }
           else {
             this_choicelang_colname <- this_choicelang
           }
-          
+
           extension[nrow(extension), this_choicelang_colname] <- list(list(list(
             values = unlist(choice_values),
             labels = unlist(these_choicelabels)

--- a/R/form_schema_ext.R
+++ b/R/form_schema_ext.R
@@ -66,10 +66,14 @@
 #'   \item \code{choices} A list of lists containing at least \code{values} and,
 #'     if available, \code{labels} of the choices as given in the form schema.
 #'     If specific languages are available, this column will return the
-#'     \code{default} language or it will be empty if this is not specified.
+#'     \code{default} language or it will be empty if this is not specified. 
+#'     Please notice that whenever choice filters are applied, this will return
+#'     the unfiltered choice list.
 #'   \item \code{choices_lang} A list of lists containing at least
 #'     \code{values} and, if available, \code{labels} of the choices in language
 #'     \emph{_lang} as given in the form schema.
+#'     Please notice that whenever choice filters are applied, this will return
+#'     the unfiltered choice list.
 #'
 #'   }
 # nolint start

--- a/man/form_schema_ext.Rd
+++ b/man/form_schema_ext.Rd
@@ -100,9 +100,13 @@ A tibble containing the form definition.
     if available, \code{labels} of the choices as given in the form schema.
     If specific languages are available, this column will return the
     \code{default} language or it will be empty if this is not specified.
+    Please notice that whenever choice filters are applied, this will return
+    the unfiltered choice list.
   \item \code{choices_lang} A list of lists containing at least
     \code{values} and, if available, \code{labels} of the choices in language
     \emph{_lang} as given in the form schema.
+    Please notice that whenever choice filters are applied, this will return
+    the unfiltered choice list.
 
   }
 }

--- a/tests/testthat/test-form_schema_ext.R
+++ b/tests/testthat/test-form_schema_ext.R
@@ -78,7 +78,8 @@ test_that("form_schema_ext v8 in a form with no languages and choice filter", {
       # pw = get_test_pw(),
       # odkc_version = get_test_odkc_version()
     )
-    question_with_choice_list <- fsx %>% subset(name == "choice_filter_question_2") 
+    question_with_choice_list <- fsx %>% subset(
+      name == "choice_filter_question_2")
   })
   testthat::expect_true(tibble::is_tibble(fsx))
   testthat::expect_true("label" %in% names(fsx))
@@ -86,7 +87,8 @@ test_that("form_schema_ext v8 in a form with no languages and choice filter", {
   testthat::expect_false(is.na(question_with_choice_list$choices))
 })
 
-test_that("form_schema_ext v8 in a form with label and choices languages and choice filter", {
+test_that(
+  "form_schema_ext v8 in a form with label and choices languages and choice filter", {
   vcr::use_cassette("test_form_schema_ext3", {
     fsx <- form_schema_ext(
       # pid = get_test_pid(),
@@ -96,7 +98,7 @@ test_that("form_schema_ext v8 in a form with label and choices languages and cho
       # pw = get_test_pw(),
       # odkc_version = get_test_odkc_version()
     )
-    question_with_choice_list <- fsx %>% subset(name == "choice_filter_question_2") 
+    question_with_choice_list <- fsx %>% subset(name == "choice_filter_question_2")
   })
   testthat::expect_true(tibble::is_tibble(fsx))
   testthat::expect_true("label" %in% names(fsx))

--- a/tests/testthat/test-form_schema_ext.R
+++ b/tests/testthat/test-form_schema_ext.R
@@ -67,4 +67,46 @@ test_that("form_schema_ext v8 in a form with label and choices languages", {
   testthat::expect_true("choices_english_(en)" %in% names(fsx))
   testthat::expect_true("choices_french_(fr)" %in% names(fsx))
 })
+
+test_that("form_schema_ext v8 in a form with no languages and choice filter", {
+  vcr::use_cassette("test_form_schema_ext4", {
+    fsx <- form_schema_ext(
+      # pid = get_test_pid(),
+      # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
+      # url = get_test_url(),
+      # un = get_test_un(),
+      # pw = get_test_pw(),
+      # odkc_version = get_test_odkc_version()
+    )
+    question_with_choice_list <- fsx %>% subset(name == "choice_filter_question_2") 
+  })
+  testthat::expect_true(tibble::is_tibble(fsx))
+  testthat::expect_true("label" %in% names(fsx))
+  testthat::expect_true("choices" %in% names(fsx))
+  testthat::expect_false(is.na(question_with_choice_list$choices))
+})
+
+test_that("form_schema_ext v8 in a form with label and choices languages and choice filter", {
+  vcr::use_cassette("test_form_schema_ext3", {
+    fsx <- form_schema_ext(
+      # pid = get_test_pid(),
+      # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
+      # url = get_test_url(),
+      # un = get_test_un(),
+      # pw = get_test_pw(),
+      # odkc_version = get_test_odkc_version()
+    )
+    question_with_choice_list <- fsx %>% subset(name == "choice_filter_question_2") 
+  })
+  testthat::expect_true(tibble::is_tibble(fsx))
+  testthat::expect_true("label" %in% names(fsx))
+  testthat::expect_true("choices" %in% names(fsx))
+  testthat::expect_true("label_english_(en)" %in% names(fsx))
+  testthat::expect_true("label_french_(fr)" %in% names(fsx))
+  testthat::expect_true("choices_english_(en)" %in% names(fsx))
+  testthat::expect_true("choices_french_(fr)" %in% names(fsx))
+  testthat::expect_false(is.na(question_with_choice_list$`choices_english_(en)`))
+})
+
+
 # usethis::edit_file("R/form_schema_ext.R") # nolint

--- a/tests/testthat/test-form_schema_ext.R
+++ b/tests/testthat/test-form_schema_ext.R
@@ -71,12 +71,12 @@ test_that("form_schema_ext v8 in a form with label and choices languages", {
 test_that("form_schema_ext v8 in a form with no languages and choice filter", {
   vcr::use_cassette("test_form_schema_ext4", {
     fsx <- form_schema_ext(
-      # pid = get_test_pid(),
-      # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
-      # url = get_test_url(),
-      # un = get_test_un(),
-      # pw = get_test_pw(),
-      # odkc_version = get_test_odkc_version()
+      pid = get_test_pid(),
+      fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
+      url = get_test_url(),
+      un = get_test_un(),
+      pw = get_test_pw(),
+      odkc_version = get_test_odkc_version()
     )
     question_with_choice_list <- fsx %>% subset(
       name == "choice_filter_question_2"
@@ -96,12 +96,12 @@ test_that(
   {
     vcr::use_cassette("test_form_schema_ext5", {
       fsx <- form_schema_ext(
-        # pid = get_test_pid(),
-        # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
-        # url = get_test_url(),
-        # un = get_test_un(),
-        # pw = get_test_pw(),
-        # odkc_version = get_test_odkc_version()
+        pid = get_test_pid(),
+        fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
+        url = get_test_url(),
+        un = get_test_un(),
+        pw = get_test_pw(),
+        odkc_version = get_test_odkc_version()
       )
       question_with_choice_list <- fsx %>% subset(
         name == "choice_filter_question_2"

--- a/tests/testthat/test-form_schema_ext.R
+++ b/tests/testthat/test-form_schema_ext.R
@@ -79,7 +79,8 @@ test_that("form_schema_ext v8 in a form with no languages and choice filter", {
       # odkc_version = get_test_odkc_version()
     )
     question_with_choice_list <- fsx %>% subset(
-      name == "choice_filter_question_2")
+      name == "choice_filter_question_2"
+    )
   })
   testthat::expect_true(tibble::is_tibble(fsx))
   testthat::expect_true("label" %in% names(fsx))
@@ -88,27 +89,36 @@ test_that("form_schema_ext v8 in a form with no languages and choice filter", {
 })
 
 test_that(
-  "form_schema_ext v8 in a form with label and choices languages and choice filter", {
-  vcr::use_cassette("test_form_schema_ext5", {
-    fsx <- form_schema_ext(
-      # pid = get_test_pid(),
-      # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
-      # url = get_test_url(),
-      # un = get_test_un(),
-      # pw = get_test_pw(),
-      # odkc_version = get_test_odkc_version()
-    )
-    question_with_choice_list <- fsx %>% subset(name == "choice_filter_question_2")
-  })
-  testthat::expect_true(tibble::is_tibble(fsx))
-  testthat::expect_true("label" %in% names(fsx))
-  testthat::expect_true("choices" %in% names(fsx))
-  testthat::expect_true("label_english_(en)" %in% names(fsx))
-  testthat::expect_true("label_french_(fr)" %in% names(fsx))
-  testthat::expect_true("choices_english_(en)" %in% names(fsx))
-  testthat::expect_true("choices_french_(fr)" %in% names(fsx))
-  testthat::expect_false(is.na(question_with_choice_list$`choices_english_(en)`))
-})
+  paste(
+    "form_schema_ext v8 in a form with label",
+    "and choices languages and choice filter"
+  ),
+  {
+    vcr::use_cassette("test_form_schema_ext5", {
+      fsx <- form_schema_ext(
+        # pid = get_test_pid(),
+        # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),
+        # url = get_test_url(),
+        # un = get_test_un(),
+        # pw = get_test_pw(),
+        # odkc_version = get_test_odkc_version()
+      )
+      question_with_choice_list <- fsx %>% subset(
+        name == "choice_filter_question_2"
+      )
+    })
+    testthat::expect_true(tibble::is_tibble(fsx))
+    testthat::expect_true("label" %in% names(fsx))
+    testthat::expect_true("choices" %in% names(fsx))
+    testthat::expect_true("label_english_(en)" %in% names(fsx))
+    testthat::expect_true("label_french_(fr)" %in% names(fsx))
+    testthat::expect_true("choices_english_(en)" %in% names(fsx))
+    testthat::expect_true("choices_french_(fr)" %in% names(fsx))
+    testthat::expect_false(is.na(
+      question_with_choice_list$`choices_english_(en)`
+    ))
+  }
+)
 
 
 # usethis::edit_file("R/form_schema_ext.R") # nolint

--- a/tests/testthat/test-form_schema_ext.R
+++ b/tests/testthat/test-form_schema_ext.R
@@ -89,7 +89,7 @@ test_that("form_schema_ext v8 in a form with no languages and choice filter", {
 
 test_that(
   "form_schema_ext v8 in a form with label and choices languages and choice filter", {
-  vcr::use_cassette("test_form_schema_ext3", {
+  vcr::use_cassette("test_form_schema_ext5", {
     fsx <- form_schema_ext(
       # pid = get_test_pid(),
       # fid = Sys.getenv("CHANGETHIS", unset = "CHANGETHIS"),


### PR DESCRIPTION
Closes #105 

When using `form_schema_ext` the choice lists are missing for select types when a `choice_filter` is applied.

This update covers this case with and without languages.

**Test forms:**

[sample_xlsform_no_languages_choicefilter.xlsx](https://github.com/ropensci/ruODK/files/5570085/sample_xlsform_no_languages_choicefilter.xlsx)

[sample_xlsform_label_and_choice_languages_choicefilter.xlsx](https://github.com/ropensci/ruODK/files/5570089/sample_xlsform_label_and_choice_languages_choicefilter.xlsx)

**Action needed**
Tests passed locally, in my own ODK Central Cloud deployment. For obvious reasons, the tests in https://github.com/mtyszler/ruODK/blob/fce2aadcf4e7fea50f0dc357cdf9feb4f507c65f/tests/testthat/test-form_schema_ext.R have just a place holder.

I marked here https://github.com/mtyszler/ruODK/commit/fce2aadcf4e7fea50f0dc357cdf9feb4f507c65f where changes will be needed.
